### PR TITLE
Allow relationships on dicts and lists.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,3 +63,4 @@ Authors
 -------
 
 Charles-Axel Dein <charles@uber.com>
+Erik Formella <erik@uber.com>

--- a/charlatan/fixtures_manager.py
+++ b/charlatan/fixtures_manager.py
@@ -12,7 +12,8 @@ from charlatan.file_format import load_file
 # TODO: check if the row still exists instead of requiring clean cache
 
 
-ALLOWED_HOOKS = ("before_save", "after_save", "before_install", "after_install")
+ALLOWED_HOOKS = ("before_save", "after_save", "before_install",
+                 "after_install")
 
 
 def is_sqlalchemy_model(instance):
@@ -150,7 +151,7 @@ class FixturesManager(object):
 
         else:
             self._get_hook("after_install")(None)
-            return instance
+            return (fixture_key, instance,)
 
     def install_fixtures(self, fixture_keys, do_not_save=False,
                          include_relationships=True):
@@ -188,9 +189,10 @@ class FixturesManager(object):
         :rtype: list of :data:`fixture_instance`
         """
 
-        return self.install_fixtures(self.fixtures.keys(),
-                                     do_not_save=do_not_save,
-                                     include_relationships=include_relationships)
+        return self.install_fixtures(
+            self.fixtures.keys(),
+            do_not_save=do_not_save,
+            include_relationships=include_relationships)
 
     def get_fixture(self, fixture_key, include_relationships=True, attrs={}):
         """Return a fixture instance (but do not save it).
@@ -229,7 +231,13 @@ class FixturesManager(object):
 
         :rtype: list of instantiated but unsaved fixtures
         """
-        return [self.get_fixture(f, include_relationships=include_relationships) for f in fixture_keys]
+        fixtures = []
+        for f in fixture_keys:
+            fixtures.append(
+                self.get_fixture(
+                    f,
+                    include_relationships=include_relationships))
+        return fixtures
 
     def _get_hook(self, hook_name):
         """Return a hook."""

--- a/charlatan/testcase.py
+++ b/charlatan/testcase.py
@@ -36,8 +36,9 @@ class FixturesMixin(object):
         else:
             fixtures_to_install = self.fixtures
 
-        installed = self.__fixtures_manager.install(fixtures_to_install,
-                                                    do_not_save=do_not_save)
+        installed = self.__fixtures_manager.install_fixtures(
+            fixtures_to_install,
+            do_not_save=do_not_save)
 
         # Adding fixtures to the class
         for f in installed:

--- a/charlatan/testing.py
+++ b/charlatan/testing.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import
+import unittest
+
+
+class TestCase(unittest.TestCase):
+
+    def __call__(self, result=None):
+        """Run a test without having to call super in setUp and tearDown"""
+
+        self._pre_setup()
+
+        unittest.TestCase.__call__(self, result)
+
+        self._post_teardown()
+
+    def _pre_setup(self):
+        pass
+
+    def _post_teardown(self):
+        pass

--- a/charlatan/tests/data/relationships_without_models.yaml
+++ b/charlatan/tests/data/relationships_without_models.yaml
@@ -1,0 +1,15 @@
+simple_dict:
+  fields:
+    field1: lolin
+    field2: 2
+
+dict_with_nest:
+  fields:
+    field1: asdlkf
+    field2: 4
+    simple_dict: !rel simple_dict
+
+list_of_relationships:
+  fields:
+    - !rel dict_with_nest
+    - !rel simple_dict

--- a/charlatan/tests/test_relationships_without_models.py
+++ b/charlatan/tests/test_relationships_without_models.py
@@ -1,0 +1,21 @@
+from __future__ import absolute_import
+
+from charlatan import testcase, testing, FixturesManager
+
+
+class TestRelationshipsWithoutModels(testing.TestCase, testcase.FixturesMixin):
+
+    fixtures = ('dict_with_nest', 'simple_dict', 'list_of_relationships',)
+
+    def setUp(self):
+        fm = FixturesManager()
+        fm.load('./charlatan/tests/data/relationships_without_models.yaml')
+
+        self.use_fixtures_manager(fm)
+
+    def test_dictionaries_nest(self):
+        self.assertEqual(self.dict_with_nest['simple_dict'], self.simple_dict)
+
+    def test_relationships_list(self):
+        self.assertEqual([self.dict_with_nest, self.simple_dict],
+                         self.list_of_relationships)

--- a/charlatan/utils.py
+++ b/charlatan/utils.py
@@ -106,7 +106,7 @@ def extended_timedelta(**kwargs):
     return datetime.timedelta(**kwargs)
 
 # TODO: does not copy the function signature
-# see http://stackoverflow.com/questions/2982974/copy-call-signature-to-decorator
+# see http://stackoverflow.com/questions/2982974/copy-call-signature-to-decorator  # noqa
 
 
 def copy_docstring_from(klass):


### PR DESCRIPTION
Charlatan 0.2.4 introduced the ability to define dicts and lists, but
they couldnt reference other objects with `!rel`. This enables that
functionality.

Also included:
- PEP8 cleanup
