### PR TITLE
Fix regression in return type of install_fixtures.

### DIFF
--- a/charlatan/fixtures_manager.py
+++ b/charlatan/fixtures_manager.py
@@ -151,7 +151,7 @@ class FixturesManager(object):
 
         else:
             self._get_hook("after_install")(None)
-            return (fixture_key, instance,)
+            return instance
 
     def install_fixtures(self, fixture_keys, do_not_save=False,
                          include_relationships=True):

--- a/charlatan/testcase.py
+++ b/charlatan/testcase.py
@@ -1,6 +1,3 @@
-import operator
-
-
 class FixturesMixin(object):
 
     """Class from which test cases should inherit to use fixtures."""
@@ -41,12 +38,11 @@ class FixturesMixin(object):
             do_not_save=do_not_save)
 
         # Adding fixtures to the class
-        for f in installed:
-            # First item is fixture name, second is fixture instance
-            setattr(self, f[0], f[1])
+        for fixture_name, fixture in zip(fixtures_to_install, installed):
+            setattr(self, fixture_name, fixture)
 
         # Return list of fixture instances
-        return map(operator.itemgetter(1), installed)
+        return installed
 
     def install_fixture(self, fixture_name):
         """Install a fixture and return it."""

--- a/charlatan/tests/test_fixtures_manager.py
+++ b/charlatan/tests/test_fixtures_manager.py
@@ -1,0 +1,21 @@
+from __future__ import absolute_import
+
+from charlatan import testing, FixturesManager
+
+
+class TestFixturesManager(testing.TestCase):
+
+    def setUp(self):
+        self.fixtures_manager = FixturesManager()
+        self.fixtures_manager.load(
+            './charlatan/tests/data/relationships_without_models.yaml')
+
+    def test_install_fixture(self):
+        """install_fixture should return the fixture"""
+
+        fixture = self.fixtures_manager.install_fixture('simple_dict')
+
+        self.assertEqual(fixture, {
+            'field1': 'lolin',
+            'field2': 2,
+        })


### PR DESCRIPTION
The `FixturesMixin` in `testcase.py` wasn't using the same api as the
rest of the module. I (erik formella) mistakenly changed the return type
of `FixturesManager.install_fixture` thinking it was an internal api so
the test code would work. This broke some people's implementations.

This brings the test Mixin inline with the old api.

tl;dr Charles will hate it but Travis will love it: Adding a test case
to this library caused a regression. </troll>
