### PR TITLE
Add the possibility to uninstall fixtures

### DIFF
--- a/charlatan/tests/test_fixtures_manager.py
+++ b/charlatan/tests/test_fixtures_manager.py
@@ -8,7 +8,7 @@ from charlatan import FixturesManager
 class TestFixturesManager(testing.TestCase):
 
     def test_install_fixture(self):
-        """install_fixture should return the fixture"""
+        """install_fixture should return the fixture."""
 
         fixtures_manager = FixturesManager()
         fixtures_manager.load(
@@ -20,6 +20,65 @@ class TestFixturesManager(testing.TestCase):
             'field1': 'lolin',
             'field2': 2,
         })
+
+    def test_uninstall_fixture(self):
+        """uninstall_fixture should return the fixture."""
+
+        fixtures_manager = FixturesManager()
+        fixtures_manager.load(
+            './charlatan/tests/data/relationships_without_models.yaml')
+
+        fixtures_manager.install_fixture('simple_dict')
+        fixture = fixtures_manager.uninstall_fixture('simple_dict')
+        self.assertEqual(fixture, {
+            'field1': 'lolin',
+            'field2': 2,
+        })
+
+        # verify we are forgiving with list inputs
+        fixtures = fixtures_manager.install_fixtures('simple_dict')
+        self.assertEqual(len(fixtures), 1)
+
+        fixtures = fixtures_manager.uninstall_fixtures('simple_dict')
+        self.assertEqual(len(fixtures), 1)
+        self.assertEqual(fixtures[0], {
+            'field1': 'lolin',
+            'field2': 2,
+        })
+
+    def test_uninstall_non_installed_fixture(self):
+        """uninstall_fixture should return None.
+
+        The method returns None since the fixture has not been previously
+        installed.
+        """
+
+        fixtures_manager = FixturesManager()
+        fixtures_manager.load(
+            './charlatan/tests/data/relationships_without_models.yaml')
+
+        fixture = fixtures_manager.uninstall_fixture('simple_dict')
+        self.assertEqual(fixture, None)
+
+    def test_uninstall_fixtures(self):
+        """uninstall_fixtures should return the list of installed fixtures."""
+        fixtures_manager = FixturesManager()
+        fixtures_manager.load(
+            './charlatan/tests/data/relationships_without_models.yaml')
+
+        fixture_keys = ('simple_dict', 'dict_with_nest')
+
+        fixtures_manager.install_fixtures(fixture_keys)
+        self.assertEqual(len(fixtures_manager.cache.keys()), 2)
+
+        fixtures = fixtures_manager.uninstall_fixtures(fixture_keys)
+        self.assertEqual(len(fixtures), 2)
+        self.assertEqual(len(fixtures_manager.cache.keys()), 0)
+
+        # uninstalling non-exiting fixtures should not raise an exception
+        fixtures = fixtures_manager.uninstall_fixtures(fixture_keys)
+        self.assertEqual(len(fixtures), 0)
+        self.assertEqual(len(fixtures_manager.cache.keys()), 0)
 
     def test_dependency_parsing(self):
         fm = FixturesManager()

--- a/charlatan/tests/test_testcase.py
+++ b/charlatan/tests/test_testcase.py
@@ -1,0 +1,109 @@
+from __future__ import absolute_import
+
+from charlatan import testcase
+from charlatan import testing
+from charlatan import FixturesManager
+
+
+fixtures_manager = FixturesManager()
+fixtures_manager.load(
+    './charlatan/tests/data/relationships_without_models.yaml')
+
+
+class TestTestCase(testing.TestCase, testcase.FixturesManagerMixin):
+
+    fixtures = (
+        'simple_dict',
+        'dict_with_nest',)
+
+    def _pre_setup(self):
+        self.fixtures_manager = fixtures_manager
+        self.init_fixtures()
+
+    def _post_teardown(self):
+        self.uninstall_all_fixtures()
+
+    def test_init_fixtures(self):
+        """init_fixtures should install 2 fixtures."""
+        self.uninstall_all_fixtures()
+
+        self.init_fixtures()
+        self.assertEqual(len(self.fixtures_manager.installed_keys), 2)
+
+    def test_install_fixture(self):
+        """install_fixture should return the installed fixture."""
+        self.uninstall_all_fixtures()
+
+        simple_dict = self.install_fixture('simple_dict')
+        self.assertEqual(simple_dict['field1'], 'lolin')
+        self.assertEqual(simple_dict['field2'], 2)
+
+    def test_install_fixtures(self):
+        """install_fixtures should return the list of installed fixtures."""
+        self.uninstall_all_fixtures()
+
+        fixtures = self.install_fixtures(('simple_dict', 'dict_with_nest'))
+        self.assertEqual(len(fixtures), 2)
+
+    def test_install_all_fixtures(self):
+        """install_all_fixtures should install all fixtures of the yaml file."""
+        self.uninstall_all_fixtures()
+
+        fixtures = self.install_all_fixtures()
+        self.assertEqual(len(fixtures), 3)
+
+    def test_uninstall_fixture(self):
+        """uninstall_fixture should return the uninstalled fixture."""
+        simple_dict = self.uninstall_fixture('simple_dict')
+        self.assertEqual(simple_dict['field1'], 'lolin')
+        self.assertEqual(simple_dict['field2'], 2)
+
+        dict_with_nest = self.uninstall_fixture('dict_with_nest')
+        self.assertEqual(dict_with_nest['field1'], 'asdlkf')
+        self.assertEqual(dict_with_nest['field2'], 4)
+
+        fixtures = self.uninstall_all_fixtures()
+        self.assertEqual(len(fixtures), 0)
+
+    def test_uninstall_fixtures(self):
+        """uninstall_fixtures should return the list of uninstalled fixtures."""
+        fixtures = self.uninstall_fixtures(('simple_dict', 'dict_with_nest'))
+        self.assertEqual(len(fixtures), 2)
+
+        fixtures = self.uninstall_fixtures(('simple_dict', 'dict_with_nest'))
+        self.assertEqual(len(fixtures), 0)
+
+    def test_uninstall_all_fixtures(self):
+        """uninstall_all_fixtures should uninstall all the installed fixtures.
+
+        The _pre_setup method install the 2 fixtures defined in self.fixtures:
+        'simple_dict' and 'dict_with_nest'.
+        """
+        fixtures = self.uninstall_all_fixtures()
+        self.assertEqual(len(fixtures), 2)
+
+        fixtures = self.uninstall_all_fixtures()
+        self.assertEqual(len(fixtures), 0)
+
+    def test_get_fixture(self):
+        """get_fixture should return the fixture."""
+        simple_dict = self.get_fixture('simple_dict')
+        self.assertEqual(simple_dict['field1'], 'lolin')
+        self.assertEqual(simple_dict['field2'], 2)
+
+        dict_with_nest = self.get_fixture('dict_with_nest')
+        self.assertEqual(dict_with_nest['field1'], 'asdlkf')
+        self.assertEqual(dict_with_nest['field2'], 4)
+
+    def test_get_fixtures(self):
+        """get_fixtures should return the list of fixtures."""
+        fixtures = self.get_fixtures(('simple_dict', 'dict_with_nest'))
+        self.assertEqual(len(fixtures), 2)
+
+        simple_dict = fixtures[0]
+        self.assertEqual(simple_dict['field1'], 'lolin')
+        self.assertEqual(simple_dict['field2'], 2)
+
+        dict_with_nest = fixtures[1]
+        self.assertEqual(dict_with_nest['field1'], 'asdlkf')
+        self.assertEqual(dict_with_nest['field2'], 4)

--- a/docs/hooks.rst
+++ b/docs/hooks.rst
@@ -16,6 +16,17 @@ The following hooks are available:
 * ``after_install``: called after doing anything. The callback must accept a
   single argument that will be the exception that may have been raised during
   the whole process. This function is guaranteed to be called.
+* ``before_uninstall``: called before uninstalling fixtures. The callback takes
+  no argument.
+* ``before_delete``: called before deleting an instance using either the
+  SQLAlchemy session or in the following order `delete_instance` and `delete`.
+  The callback takes a single argument which is the instance being deleted.
+* ``after_delete``: called after deleting an instance using either the
+  SQLAlchemy session or in the following order `delete_instance` and `delete`.
+  The callback takes a single argument which is the instance that was deleted.
+* ``after_uninstall``: called after uninstalling fixtures. The callback must
+  accept a single argument that will be the exception that may have been raised
+  during the whole process. This function is guaranteed to be called.
 
 .. automethod:: charlatan.FixturesManager.set_hook
     :noindex:

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -61,8 +61,8 @@ Using fixtures
 
 There are multiple ways to require and use fixtures.
 
-For each tests, in setUp
-""""""""""""""""""""""""
+For each tests, in setUp and tearDown
+"""""""""""""""""""""""""""""""""""""
 
 .. code-block:: python
 
@@ -72,16 +72,21 @@ For each tests, in setUp
             # This will create self.client and self.driver
             self.install_fixtures(("client", "driver"))
 
+        def tearDown(self):
+            # This will delete self.client and self.driver
+            self.uninstall_fixtures(("client", "driver"))
+
 For a single test
 """""""""""""""""
 
 .. code-block:: python
 
-  class MyTest(FixturesManagerMixin):
+    class MyTest(FixturesMixin):
 
-      def test_toaster(self):
-          self.install_fixtures("toaster")
-
+        def test_toaster(self):
+            self.install_fixture("toaster")
+            # do things... and optionally uninstall it once you're done
+            self.uninstall_fixture("toaster")
 
 Getting a fixture without saving it
 """""""""""""""""""""""""""""""""""


### PR DESCRIPTION
This feature adds the capability to uninstall fixtures using one or a set of fixture keys.

We know that the `FixturesManager` class has a `save_instance` method and several `install_fixture` related methods. In a similar way and for parity sake we add a `delete_instance` as well as several `uninstall_fixture` methods.
### Why is that useful?

This is how things were before:

``` python
class TestToaster(unittest.TestCase, charlatan.testcase.FixturesMixin):

    def setUp(self):
        self.install_fixture('toast') # this feels magical

    def tearDown(self):
        toast_fixture = self.get_fixture('toast')
        toast = Toast.get(Toast.id == toast_fixture.id)
        self.session.delete(toast)
        self.session.commit() # why not the same magical pattern?
```

And now you'll be able to do:

``` python
class TestToaster(unittest.TestCase, charlatan.testcase.FixturesMixin):

    def setUp(self):
        self.install_fixture('toast') # this feels magical

    def tearDown(self):
        self.uninstall_fixture('toast') # this also feels magical
```
### How the magic works?

When calling `FixturesManager.delete_instance`, the logic expects (and hopes) that your model instance will have a `Model.delete_instance()` method or a `Model.delete()` method. If it has both, only `Model.delete_instance` will be called. This works for peewee and other standard orm. It is very similar to how the `FixturesManager.save_instance` method relies on the `Model.save()` method being defined by your orm.
### Limitations
- deleting is trivial and not recursive (not even an option because too orm-specific)
- make sure your fixtures are set in a additive order in terms of relationships: objects with dependencies set after in the yaml, in an additive manner
