### PR TITLE
Fix glob wildcard bug

### DIFF
--- a/charlatan/fixtures_manager.py
+++ b/charlatan/fixtures_manager.py
@@ -117,7 +117,7 @@ class FixturesManager(object):
             )
 
         if len(globbed_filenames) == 1:
-            content = load_file(filenames, self.use_unicode)
+            content = load_file(globbed_filenames[0], self.use_unicode)
         else:
             content = {}
 


### PR DESCRIPTION
If you glob a wildcard, but there is only one result, you should use that result. Not try and use the wildcard filename