### PR TITLE
Fix saving collection of fixtures to database

### DIFF
--- a/charlatan/fixtures_manager.py
+++ b/charlatan/fixtures_manager.py
@@ -292,6 +292,10 @@ class FixturesManager(object):
 
             # Save the instance
             if not do_not_save:
+                if hasattr(instance, '__iter__'):
+                    # Save all the instances!
+                    for model in instance:
+                        self.save_instance(model)
                 self.save_instance(instance)
 
         except Exception as exc:

--- a/charlatan/tests/data/relationships.yaml
+++ b/charlatan/tests/data/relationships.yaml
@@ -12,3 +12,9 @@ relationship_alone:
 from_database:
   id: 1
   model: charlatan.tests.fixtures.models:Toaster
+
+model_list:
+  inherit_from: model
+  objects:
+    - name: "one"
+    - name: "two"

--- a/charlatan/tests/test_sqlalchemy.py
+++ b/charlatan/tests/test_sqlalchemy.py
@@ -33,3 +33,9 @@ class TestSqlalchemyFixtures(testing.TestCase):
 
         toaster = self.manager.install_fixture("from_database")
         self.assertEqual(toaster.id, 1)
+
+    def test_installing_collection(self):
+        """Verify that a collection of fixtures is in the database"""
+        self.manager.install_fixture("model_list")
+
+        self.assertEqual(self.session.query(Toaster).count(), 2)


### PR DESCRIPTION
Adds ability to save a collection of fixtures (when a list is returned by get_fixture) and an associated test
