### PR TITLE
Support multiple levels of nesting for relationships

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog for Charlatan
 =======================
 
+0.3.11 (unreleased)
+-------------------
+
+- Fix getting relationships with fields that are nested more than one level
+
 0.3.10 (2014-12-31)
 -------------------
 

--- a/charlatan/fixture.py
+++ b/charlatan/fixture.py
@@ -268,7 +268,8 @@ class Fixture(Inheritable):
         # One to many relationship
         elif isinstance(field_value, (tuple, list)):
             for i, nested_value in enumerate(field_value):
-                field_value[i] = self._process_field_relationships(nested_value)
+                field_value[i] = self._process_field_relationships(
+                    nested_value)
 
         return field_value
 

--- a/charlatan/tests/data/relationships_without_models.yaml
+++ b/charlatan/tests/data/relationships_without_models.yaml
@@ -13,3 +13,11 @@ list_of_relationships:
   fields:
     - !rel dict_with_nest
     - !rel simple_dict
+
+nested_list_of_relationships:
+  fields:
+    dicts:
+      -
+        - !rel dict_with_nest
+      -
+        - !rel simple_dict

--- a/charlatan/tests/test_relationships_without_models.py
+++ b/charlatan/tests/test_relationships_without_models.py
@@ -6,7 +6,7 @@ from charlatan import testcase, testing, FixturesManager
 class TestRelationshipsWithoutModels(testing.TestCase,
                                      testcase.FixturesManagerMixin):
 
-    fixtures = ('dict_with_nest', 'simple_dict', 'list_of_relationships')
+    fixtures = ('dict_with_nest', 'simple_dict', 'list_of_relationships',)
 
     def setUp(self):
         self.fixtures_manager = FixturesManager()

--- a/charlatan/tests/test_relationships_without_models.py
+++ b/charlatan/tests/test_relationships_without_models.py
@@ -6,7 +6,8 @@ from charlatan import testcase, testing, FixturesManager
 class TestRelationshipsWithoutModels(testing.TestCase,
                                      testcase.FixturesManagerMixin):
 
-    fixtures = ('dict_with_nest', 'simple_dict', 'list_of_relationships',)
+    fixtures = ('dict_with_nest', 'simple_dict', 'list_of_relationships',
+                'nested_list_of_relationships')
 
     def setUp(self):
         self.fixtures_manager = FixturesManager()
@@ -20,3 +21,11 @@ class TestRelationshipsWithoutModels(testing.TestCase,
     def test_relationships_list(self):
         self.assertEqual([self.dict_with_nest, self.simple_dict],
                          self.list_of_relationships)
+
+    def test_nested_list_of_relationships(self):
+        self.assertEqual(self.nested_list_of_relationships, {
+            'dicts': [
+                [self.dict_with_nest],
+                [self.simple_dict],
+            ]
+        })

--- a/charlatan/tests/test_relationships_without_models.py
+++ b/charlatan/tests/test_relationships_without_models.py
@@ -6,8 +6,7 @@ from charlatan import testcase, testing, FixturesManager
 class TestRelationshipsWithoutModels(testing.TestCase,
                                      testcase.FixturesManagerMixin):
 
-    fixtures = ('dict_with_nest', 'simple_dict', 'list_of_relationships',
-                'nested_list_of_relationships')
+    fixtures = ('dict_with_nest', 'simple_dict', 'list_of_relationships')
 
     def setUp(self):
         self.fixtures_manager = FixturesManager()
@@ -23,7 +22,10 @@ class TestRelationshipsWithoutModels(testing.TestCase,
                          self.list_of_relationships)
 
     def test_nested_list_of_relationships(self):
-        self.assertEqual(self.nested_list_of_relationships, {
+        nested_list_of_relationships = self.install_fixture(
+            'nested_list_of_relationships')
+
+        self.assertEqual(nested_list_of_relationships, {
             'dicts': [
                 [self.dict_with_nest],
                 [self.simple_dict],

--- a/charlatan/tests/test_testcase.py
+++ b/charlatan/tests/test_testcase.py
@@ -50,7 +50,7 @@ class TestTestCase(testing.TestCase, testcase.FixturesManagerMixin):
         self.uninstall_all_fixtures()
 
         fixtures = self.install_all_fixtures()
-        self.assertEqual(len(fixtures), 3)
+        self.assertEqual(len(fixtures), 4)
 
     def test_uninstall_fixture(self):
         """uninstall_fixture should return the uninstalled fixture."""


### PR DESCRIPTION
At the moment this type of fixture is not supported:

```
job:
  fields:
    messages:
      -
        - !rel user1.id
        - "some content"

      -
        - !rel user2.id
        - "some more content for another user"
```

The `!rel user1.id` ends up turning into `user1.id` because we only
look at the first two levels.

This diff seeks to support parsing relationships for multiple levels of
nesting.