### PR TITLE
Fixed FixtureManager.delete_fixture to use the injected builder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog for Charlatan
 =======================
 
+(unreleased)
+------------
+
+- Fixed bug where uninstalling a sqlalchemy fixture would not commit the delete
+  to the session.
+
 0.4.1 (2015-02-26)
 ------------------
 

--- a/charlatan/fixtures_manager.py
+++ b/charlatan/fixtures_manager.py
@@ -255,7 +255,7 @@ class FixturesManager(object):
         if instance:
             self.cache.pop(fixture_key, None)
             self.installed_keys.remove(fixture_key)
-            self.delete_builder(self, instance)
+            builder(self, instance)
 
         self.get_hook("after_delete")(fixture_key)
 

--- a/charlatan/tests/test_sqlalchemy.py
+++ b/charlatan/tests/test_sqlalchemy.py
@@ -51,3 +51,14 @@ class TestSqlalchemyFixtures(testing.TestCase):
         """Verify that we can get a db-computed foreign key explicitely."""
         model = self.manager.install_fixture('model_with_explicit_fk')
         assert model.color_id is not None
+
+    def test_uninstall_deletes_fixtures(self):
+        """Verify uninstalling a fixture drops it from the database"""
+        self.manager.install_fixture("color")
+
+        # sanity check
+        self.assertEqual(self.session.query(Color).count(), 1)
+
+        self.manager.uninstall_fixture("color")
+
+        self.assertEqual(self.session.query(Color).count(), 0)


### PR DESCRIPTION
By using the builder on `self.delete_builder` instead of the injected builder (partial with commit=True) the delete itself was failing to be committed to the session for sqlalchemy fixtures.