### PR TITLE
Fixed AttributeError bug where accessing fields of another dict

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog for Charlatan
 
 - Fixed bug where uninstalling a sqlalchemy fixture would not commit the delete
   to the session.
+- Fixed bug where dict fixtures could not reference fields from other collections of dicts.
 
 0.4.1 (2015-02-26)
 ------------------

--- a/charlatan/fixture.py
+++ b/charlatan/fixture.py
@@ -1,10 +1,9 @@
 import copy
 import importlib
-import operator
 
 from charlatan import _compat
 from charlatan.file_format import RelationshipToken
-from charlatan.utils import safe_iteritems
+from charlatan.utils import safe_iteritems, richgetter
 
 CAN_BE_INHERITED = frozenset(
     ["model_name", "models_package", "fields", "post_creation", "depend_on"])
@@ -179,7 +178,7 @@ class Fixture(Inheritable):
             setattr(instance, attr, value)
 
         if path:
-            return operator.attrgetter(path)(instance)
+            return richgetter(instance, path)
         else:
             return instance
 

--- a/charlatan/tests/data/relationships_without_models.yaml
+++ b/charlatan/tests/data/relationships_without_models.yaml
@@ -21,3 +21,13 @@ nested_list_of_relationships:
         - !rel dict_with_nest
       -
         - !rel simple_dict
+
+parent_dict:
+  objects:
+    object1:
+      field1: 100
+
+child_dict:
+  objects:
+    object1:
+      field1: !rel parent_dict.object1.field1

--- a/charlatan/tests/test_relationships_without_models.py
+++ b/charlatan/tests/test_relationships_without_models.py
@@ -31,3 +31,9 @@ class TestRelationshipsWithoutModels(testing.TestCase,
                 [self.simple_dict],
             ]
         })
+
+    def test_relationships_dict_attribute(self):
+        parent = self.install_fixture('parent_dict.object1')
+        child = self.install_fixture('child_dict.object1')
+
+        self.assertEquals(child['field1'], parent['field1'])

--- a/charlatan/tests/test_testcase.py
+++ b/charlatan/tests/test_testcase.py
@@ -40,7 +40,7 @@ class TestTestCase(testing.TestCase, testcase.FixturesManagerMixin):
         self.uninstall_all_fixtures()
 
         fixtures = self.install_all_fixtures()
-        self.assertEqual(len(fixtures), 4)
+        self.assertEqual(len(fixtures), 6)
 
     def test_uninstall_fixture(self):
         self.uninstall_fixture('simple_dict')


### PR DESCRIPTION
When using dict only fixtures, I'm receiving `AttributeError`s when trying to reference other dicts.

Example:

```yaml
users:
  objects:
    caleb:
        id: 1

messages:
  objects:
    message_to_caleb:
      user_id: !rel users.caleb.id
```

When attempting to install the `messages.message_to_caleb` fixture via
install_fixture, an `AttributeError` would be raised while trying to
access the attribute `id` on `users.caleb`.

```
AttributeError: 'dict' object has no attribute 'id'
```

This PR attempts to fix that.