### PR TITLE
Fix anonymous list objects name resolution resolves #47

### DIFF
--- a/charlatan/tests/test_richgetter.py
+++ b/charlatan/tests/test_richgetter.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import
+
+from charlatan import testing
+from charlatan.utils import richgetter
+
+
+class TestRichGetter(testing.TestCase):
+    def test_resolves_objects(self):
+        obj = Namespace(key=Namespace(value='value'))
+
+        result = richgetter(obj, 'key.value')
+
+        self.assertEquals(result, 'value')
+
+    def test_resolves_mappings(self):
+        obj = dict(key=dict(value='value'))
+
+        result = richgetter(obj, 'key.value')
+
+        self.assertEquals(result, 'value')
+
+    def test_resolves_sequences(self):
+        obj = [['value']]
+
+        result = richgetter(obj, '0.0')
+
+        self.assertEquals(result, 'value')
+
+    def test_resolves_mixed_containers(self):
+        obj = Namespace(key=dict(values=['value']))
+
+        result = richgetter(obj, 'key.values.0')
+
+        self.assertEquals(result, 'value')
+
+
+class Namespace(object):
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)

--- a/charlatan/utils.py
+++ b/charlatan/utils.py
@@ -4,6 +4,7 @@ import functools
 import itertools
 import operator
 import re
+import collections
 
 from charlatan import _compat
 
@@ -170,9 +171,11 @@ def is_sqlalchemy_model(instance):
 def richgetter(obj, path):
     """Return a attrgetter + item getter."""
     for name in path.split("."):
-        if hasattr(obj, name):
+        if isinstance(obj, collections.Mapping):
+            obj = obj[name]
+        elif isinstance(obj, collections.Sequence):
+            obj = obj[int(name)]  # force int type for list indexes
+        else:
             obj = getattr(obj, name)
-            continue
-        obj = obj[name]
 
     return obj


### PR DESCRIPTION
Generalized `charlatan.utils.richgetter` function to resolve object paths including `dict`, `object` and `list`.

It uses instance type comparision against standard `collection` ABC metaclasses.
- Instances of *Mapping* should implement `getitem`
- Instances of *Sequence* should implement `getitem` also, but indexes are numerical.
- Other kind of objects resolve to attribute access.

```python
>>> import collections
>>> isinstance(list(), collections.Sequence)
True
>>> isinstance(list(), collections.Mapping)
False
>>> isinstance(dict(), collections.Sequence)
False
>>> isinstance(dict(), collections.Mapping)
True
>>> isinstance(object(), collections.Sequence)
False
>>> isinstance(object(), collections.Mapping)
False
```

As in the tests, the spec `object.values.0` should resolve to `'value'` in this context:

```python
>>> obj = Namespace(key=dict(values=['value'])))
>>> richgetter(obj, 'key.values.0')
'value'
```

Note that previous implementation would have resolved `key.values` to the `dict.values()` method instead of `dict['values']` which is the correct thing to do.

This should fix #47 as it now handles list indexes correctly.

Thanks for such a nice library :)